### PR TITLE
Filter on campaign.id instead of campaign.name

### DIFF
--- a/v2 pMax charts - 30 day version
+++ b/v2 pMax charts - 30 day version
@@ -4,9 +4,7 @@
 // outcome: build queries, grab data, push to sheet - 30 day version
 //
 // step 1: create a copy of this sheet first https://docs.google.com/spreadsheets/d/1B7N1XbESpPhSbidtk7D3To2_2YTFeJqdTMzooN4sN5A/copy
-// enter url of YOUR sheet in line 11 between the single quotes
-//
-// then change the naming convention on line 16 to match your pMax campaigns, again between the single quotes
+// enter url of YOUR sheet in line 12 between the single quotes
 //
 
 function main() {

--- a/v2 pMax charts - 30 day version
+++ b/v2 pMax charts - 30 day version
@@ -13,9 +13,6 @@ function main() {
 
   let ss = SpreadsheetApp.openByUrl('');   // enter url of your sheet here
   
-  let myCampaignNamingConvention = 'Performance';   // change as needed, eg pMax
-  
-  
   // don't change anything below this line *************************
   
   
@@ -28,26 +25,33 @@ function main() {
   let value         = ' metrics.conversions_value '; 
   let views         = ' metrics.video_views ';
   let cpv           = ' metrics.average_cpv ';
+  let id            = ' campaign.id ';
   let date_and_cost = ' segments.date DURING LAST_30_DAYS AND metrics.cost_micros > 0 '; // 30 day version
   let order         = ' ORDER BY campaign.name ';   
 
+  let campIdReportRows = AdsApp.report('SELECT campaign.id FROM campaign WHERE campaign.advertising_channel_type = "PERFORMANCE_MAX"').rows();
+  let campIds = [];
+  while (campIdReportRows.hasNext()) {
+    campIds.push(campIdReportRows.next()['campaign.id']);
+  }
+  
   let cd = [segDate, name, cost, conv, value, views, cpv]
   let campDateQuery = 'SELECT ' + cd.join(',') + 
       ' FROM campaign ' +
       ' WHERE ' + date_and_cost + 
-      ' AND campaign.name LIKE "%'+ myCampaignNamingConvention +'%" ' + order ; 
+      ' AND campaign.id IN ("' + campIds.join('","') + '")' + order;
 
-  let pd = [segDate, name, title, cost, conv, value]
+  let pd = [segDate, name, title, cost, conv, value, id]
   let prodDateQuery = 'SELECT ' + pd.join(',')  + 
       ' FROM shopping_performance_view  ' + 
       ' WHERE ' + date_and_cost + 
-      ' AND campaign.name LIKE "%'+ myCampaignNamingConvention +'%" ' + order ; 
+      ' AND campaign.id IN ("' + campIds.join('","') + '")' + order ; 
 
   runReport(campDateQuery, ss.getSheetByName('camp'));  
   runReport(prodDateQuery, ss.getSheetByName('prod')); 
 }
 
-function runReport(q,sh) {
+function runReport(q, sh) {
   const report = AdsApp.report(q);
   report.exportToSheet(sh);  
 }


### PR DESCRIPTION
To make it even easier to use the script, I have modified the script to filter on campaign.id instead of the campaign.name. The list of campaign IDs is build by running a query that gets all campaign IDs of campaigns where `campaign.advertising_channel_type = "PERFORMANCE_MAX"`.

Another idea I had, is to make it possible to run this script on MCC level. For that to work, we would need to append the report rows for each account instead of overwriting a previous execution. Do you think this would be useful?